### PR TITLE
[IMP] stock_release_channel: stock picking indexing

### DIFF
--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -13,7 +13,7 @@ class StockPicking(models.Model):
 
     release_channel_id = fields.Many2one(
         comodel_name="stock.release.channel",
-        index=True,
+        index="btree_not_null",
         ondelete="restrict",
         copy=False,
         tracking=True,


### PR DESCRIPTION
Use a `btree_not_null` index for `stock_picking.release_channel_id`, as many pickings in a given database will not have a release channel set (on the customer database I'm checking this, only 20% of the pickings have a release channel set). 

In that case `btree_not_null` will result in a smaller index, less index maintenance and better overall performance.