### PR TITLE
stock_release_channel_warehouse_calendar: fix OverflowError

### DIFF
--- a/stock_release_channel_warehouse_calendar/models/stock_release_channel.py
+++ b/stock_release_channel_warehouse_calendar/models/stock_release_channel.py
@@ -38,6 +38,12 @@ class StockReleaseChannel(models.Model):
             work_intervals = calendar._work_intervals_batch(
                 delivery_date, delivery_date + batch_delta, tz=wh_tz
             )[False]
+            if not work_intervals:
+                delivery_date = (
+                    yield (delivery_date + batch_delta)
+                    .astimezone(pytz.utc)
+                    .replace(tzinfo=None)
+                )
             for begin_dt_tz, end_dt_tz, _attendance in work_intervals:
                 while delivery_date <= end_dt_tz:
                     if delivery_date < begin_dt_tz:

--- a/stock_release_channel_warehouse_calendar/tests/test_channel_delivery_date.py
+++ b/stock_release_channel_warehouse_calendar/tests/test_channel_delivery_date.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Camptocamp (https://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from unittest import mock
 
 from odoo import fields
 
@@ -67,3 +68,16 @@ class TestChannelDeliveryDate(ReleaseChannelCase):
         self.assertEqual(result, opening)
         result = gen.send(dt)
         self.assertEqual(result, opening)
+
+    def test_warehouse_calendar_overflow(self):
+        self.wh.calendar_id = self.calendar
+        with mock.patch.object(
+            type(self.calendar), "_work_intervals_batch", return_value={False: []}
+        ):
+            dt = to_datetime("2025-01-05 14:30:00")  # Sunday 15:30
+            gen = self.channel._next_delivery_date_warehouse_calendar(dt)
+            result = next(gen)
+            opening = to_datetime("2025-03-07 14:30:00")  # max date limit of 61 days
+            self.assertEqual(result, opening)
+        result = gen.send(dt)
+        self.assertEqual(result, to_datetime("2025-01-06 07:00:00"))


### PR DESCRIPTION
When no interval is found the while loop never stops leading to an OverflowError or MemoryError.

When that happens, just yield the max possible date.