### PR TITLE
[18.0][FIX] stock_release_channel_shipment_lead_time: shipment_date dt to date conversion

### DIFF
--- a/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
@@ -66,9 +66,9 @@ class StockReleaseChannel(models.Model):
         for channel in self:
             shipment_date = False
             if channel.process_end_date:
-                shipment_date = channel._add_shipment_lead_time(
-                    channel.process_end_date
-                )
+                shipment_date = self._localize(
+                    channel._add_shipment_lead_time(channel.process_end_date)
+                ).date()
             channel.shipment_date = shipment_date
 
     @property


### PR DESCRIPTION
Fix bug introduced by the refactor for delivery date computation