### PR TITLE
[18.0][FIX] stock_release_channel*: delivery date computation

### DIFF
--- a/sale_stock_release_channel/models/stock_picking.py
+++ b/sale_stock_release_channel/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class StockPicking(models.Model):
@@ -13,3 +13,18 @@ class StockPicking(models.Model):
         if self.sale_id.commitment_date:
             return False
         return super()._release_channel_possible_candidate_domain_apply_extras
+
+    @api.depends("group_id")
+    def _compute_delivery_date(self):
+        # when there is an SO commitment date, always use that one as delivery date
+        for picking in self:
+            channel = picking.release_channel_id
+            if not channel or picking.need_release:
+                super(StockPicking, picking)._compute_delivery_date()
+                continue
+            commitment_date_dt = picking.group_id.sale_id.commitment_date
+            if commitment_date_dt:
+                picking.delivery_date = channel._localize(commitment_date_dt).date()
+            else:
+                super(StockPicking, picking)._compute_delivery_date()
+        return

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -2,7 +2,7 @@
 # Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import exceptions, fields, models
+from odoo import api, exceptions, fields, models
 from odoo.osv import expression
 
 from odoo.addons.queue_job.job import identity_exact
@@ -18,6 +18,10 @@ class StockPicking(models.Model):
         copy=False,
         tracking=True,
         inverse="_inverse_release_channel_id",
+    )
+
+    delivery_date = fields.Date(
+        compute="_compute_delivery_date",
     )
 
     def _inverse_release_channel_id(self):
@@ -44,6 +48,28 @@ class StockPicking(models.Model):
                 )
             all_moves = moves.browse(move_chain_ids)
             all_moves._release_set_expected_date(new_date)
+
+    @api.depends("release_channel_id", "need_release", "partner_id")
+    def _compute_delivery_date(self):
+        # compute the earliest delivery date from the scheduled date
+        for picking in self:
+            channel = picking.release_channel_id
+            if not channel or not picking.partner_id or picking.need_release:
+                picking.delivery_date = False
+                continue
+            # Use the scheduled date as preparation end date
+            steps = channel._delivery_date_steps
+            # skip any step until preparation included
+            for i, step in enumerate(steps):
+                if step == "preparation":
+                    steps = steps[i + 1 :]
+                    break
+            delivery_dt = channel._get_earliest_delivery_date(
+                picking.partner_id,
+                picking.scheduled_date,
+                steps=steps,
+            )
+            picking.delivery_date = channel._localize(delivery_dt).date()
 
     def _delay_assign_release_channel(self):
         for picking in self:

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -952,7 +952,7 @@ class StockReleaseChannel(models.Model):
         """
         return defaultdict(list)
 
-    def _get_earliest_delivery_date(self, partner, order_dt):
+    def _get_earliest_delivery_date(self, partner, start_dt, steps=None):
         """Compute the earliest delivery date for this channel
 
         Go through each steps. All generators of a step must agree on a date.
@@ -963,10 +963,11 @@ class StockReleaseChannel(models.Model):
         This algorithm performs a quick convergence to a date.
         """
         self.ensure_one()
-        best_dt = order_dt
-        limit_dt = order_dt + timedelta(days=DELIVERY_DATE_COMPUTATION_LIMIT_DAYS)
+        best_dt = start_dt
+        limit_dt = start_dt + timedelta(days=DELIVERY_DATE_COMPUTATION_LIMIT_DAYS)
         _logger.debug(f"Compute earliest delivery date starting from {best_dt}")
-        for step in self._delivery_date_steps:
+        steps = steps or self._delivery_date_steps
+        for step in steps:
             funcs = self._delivery_date_generators.get(step)
             if not funcs:
                 continue

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -965,11 +965,11 @@ class StockReleaseChannel(models.Model):
         self.ensure_one()
         best_dt = order_dt
         limit_dt = order_dt + timedelta(days=DELIVERY_DATE_COMPUTATION_LIMIT_DAYS)
+        _logger.debug(f"Compute earliest delivery date starting from {best_dt}")
         for step in self._delivery_date_steps:
             funcs = self._delivery_date_generators.get(step)
             if not funcs:
                 continue
-            _logger.debug(f"Compute earliest delivery date for {step}")
             generators = []
             best_generators = []
             start_dt = best_dt
@@ -980,6 +980,7 @@ class StockReleaseChannel(models.Model):
                 new_dt = next(gen)
                 if new_dt > best_dt:
                     best_dt = new_dt
+                    _logger.debug(f"  new {step} date {best_dt} from {gen.__name__}")
                     best_generators = [gen]
                 elif new_dt == best_dt:
                     best_generators.append(gen)
@@ -996,10 +997,14 @@ class StockReleaseChannel(models.Model):
                         continue
                     best_dt = gen.send(previous_dt := best_dt)
                     if best_dt != previous_dt:
-                        _logger.debug(f"New {step} date {best_dt} from {gen}")
+                        _logger.debug(
+                            f"  new {step} date {best_dt} from {gen.__name__}"
+                        )
                         best_generators = [gen]
                     else:
                         best_generators.append(gen)
+            gen_names = ",".join(gen.__name__ for gen in generators)
+            _logger.debug(f"  {step} date {best_dt} agreed by {gen_names}")
             for gen in generators:
                 gen.close()
             if best_dt is None:

--- a/stock_release_channel_cutoff/models/stock_release_channel.py
+++ b/stock_release_channel_cutoff/models/stock_release_channel.py
@@ -24,17 +24,15 @@ class StockReleaseChannel(models.Model):
     # Technical field for warning on kanban view
     cutoff_warning = fields.Boolean(compute="_compute_cutoff_warning")
 
-    @property
-    def cutoff_datetime(self):
+    def cutoff_datetime(self, day_dt):
         self.ensure_one()
         if not self.cutoff_time:
             return False
-        now = self.process_end_date if self.state == "open" else fields.Datetime.now()
         return time_to_datetime(
             float_to_time(
                 self.cutoff_time,
             ),
-            now=now,
+            now=day_dt,
             tz=self.process_end_time_tz,
         )
 
@@ -44,7 +42,7 @@ class StockReleaseChannel(models.Model):
         for channel in self:
             cutoff_warning = False
             if channel.state == "open" and channel.cutoff_time:
-                cutoff_warning = channel.cutoff_datetime < now
+                cutoff_warning = channel.cutoff_datetime(self.process_end_date) < now
             channel.cutoff_warning = cutoff_warning
 
     @property
@@ -64,7 +62,7 @@ class StockReleaseChannel(models.Model):
         new date to validate.
         """
         self.ensure_one()
-        cutoff = self.cutoff_datetime
+        cutoff = self.cutoff_datetime(delivery_date)
         if not cutoff:
             # any date is valid
             while True:

--- a/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
+++ b/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
@@ -93,7 +93,7 @@ class StockReleaseChannel(models.Model):
                     lambda w,
                     weekday=weekday,
                     inc=inc,
-                    delivery_date_tz=delivery_date_tz: str(weekday + inc)
+                    delivery_date_tz=delivery_date_tz: str((weekday + inc) % 7)
                     in w.time_window_weekday_ids.mapped("name")
                     and (inc or w.get_time_window_end_time() >= delivery_date_tz.time())
                 )


### PR DESCRIPTION
* [FIX] stock_release_channel_partner_delivery_window: weekday
   When comparing weekdays, restart at 0 when end of week has been reached
* [FIX] stock_release_channel_cutoff: cutoff datetime
   Use proper date for cutoff comparison
* [IMP] stock_release_channel: delivery date debug
* [IMP] add picking delivery date to communicate to transporter


cc @mmequignon @sebalix @simahawk 