### PR TITLE
[18.0][IMP] stock_release_channel_partner_delivery_window: warning

### DIFF
--- a/stock_release_channel_partner_delivery_window/models/stock_picking.py
+++ b/stock_release_channel_partner_delivery_window/models/stock_picking.py
@@ -7,6 +7,9 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def _planned_delivery_date(self):
+        return self.delivery_date
+
     @property
     def _release_channel_possible_candidate_domain_partner_delivery_window(self):
         """The delivery date must be on a partner open day"""


### PR DESCRIPTION
Use channel delivery date for warning.

Base module uses scheduled date as delivery date for warning if date is not in the partner delivery window.
Use the channel delivery date instead.

cc @simahawk 