### PR TITLE
[18.0][FIX] stock_release_channel: delivery date

### DIFF
--- a/stock_release_channel/__manifest__.py
+++ b/stock_release_channel/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Release Channels",
     "summary": "Manage workload in WMS with release channels",
-    "version": "18.0.1.5.1",
+    "version": "18.0.1.6.0",
     "development_status": "Beta",
     "license": "AGPL-3",
     "author": "Camptocamp, BCIM, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/stock_release_channel/migrations/18.0.1.6.0/post-migration.py
+++ b/stock_release_channel/migrations/18.0.1.6.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["stock.picking"].search(
+        [
+            ("picking_type_code", "=", "outgoing"),
+            ("state", "in", ("waiting", "confirmed", "assigned")),
+            ("release_channel_id", "!=", False),
+        ]
+    )._compute_delivery_date()

--- a/stock_release_channel/migrations/18.0.1.6.0/pre-migration.py
+++ b/stock_release_channel/migrations/18.0.1.6.0/pre-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+
+from odoo.tools.sql import column_exists, create_column
+
+
+def migrate(cr, version):
+    if not column_exists(cr, "stock_picking", "delivery_date"):
+        create_column(cr, "stock_picking", "delivery_date", "date")

--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -3,11 +3,32 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
+import pytz
+
 from odoo import models
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    def _release_set_expected_date(self, new_expected_date=False):
+        # Before changing the date, if there is no channel, record old date as
+        # delivery date
+        for picking in self.picking_id:
+            channel = picking.release_channel_id
+            if not channel or channel.state == "asleep":
+                if not picking.delivery_date:
+                    delivery_date = picking.scheduled_date
+                    wh_tz = pytz.timezone(
+                        picking.picking_type_id.warehouse_id.partner_id.tz
+                        or self.env.company.partner_id.tz
+                        or "UTC"
+                    )
+                    delivery_date_tz = delivery_date.astimezone(pytz.utc).astimezone(
+                        wh_tz
+                    )
+                    picking.delivery_date = delivery_date_tz.date()
+        return super()._release_set_expected_date(new_expected_date=new_expected_date)
 
     def release_available_to_promise(self):
         # after releasing, we re-assign a release channel,

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -53,6 +53,13 @@ class StockPicking(models.Model):
             all_moves = moves.browse(move_chain_ids)
             all_moves._release_set_expected_date(new_date)
 
+    def _get_partner_release_channels(self):
+        domain_order = self._release_channel_possible_candidate_domain_base
+        domain_partner = self.partner_id._release_channel_possible_candidate_domain
+        domain_channel = [("is_manual_assignment", "=", False)]
+        domain = expression.AND([domain_order, domain_partner, domain_channel])
+        return self.env["stock.release.channel"].search(domain)
+
     @api.depends(
         "release_channel_id",
         "need_release",
@@ -72,28 +79,38 @@ class StockPicking(models.Model):
             ):
                 picking.delivery_date = False
                 continue
-            channel = picking.release_channel_id
-            if not channel:
+            channels = picking.release_channel_id
+            if not channels:
+                channels = picking._get_partner_release_channels()
+            if not channels:
                 continue
             # Use the scheduled date as preparation end date
-            steps = channel._delivery_date_steps
+            steps = channels._delivery_date_steps
             # skip any step until preparation included
             for i, step in enumerate(steps):
                 if step == "preparation":
                     steps = steps[i + 1 :]
                     break
-            if picking.state == "done":
+            if picking.state == "done" and picking.date_done:
                 end_preparation_date = picking.date_done
-            else:
+            elif picking.scheduled_date:
                 end_preparation_date = max(
                     picking.scheduled_date, fields.Datetime.now()
                 )
-            delivery_dt = channel._get_earliest_delivery_date(
-                picking.partner_id,
-                end_preparation_date,
-                steps=steps,
-            )
-            picking.delivery_date = channel._localize(delivery_dt).date()
+            else:
+                end_preparation_date = fields.Datetime.now()
+            dates = []
+            for channel in channels:
+                delivery_dt = channel._get_earliest_delivery_date(
+                    picking.partner_id,
+                    end_preparation_date,
+                    steps=steps,
+                )
+                if delivery_dt:
+                    dates.append(channel._localize(delivery_dt).date())
+            if not dates:
+                continue
+            picking.delivery_date = min(dates)
 
     def _delay_assign_release_channel(self):
         for picking in self:

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -24,6 +24,8 @@ class StockPicking(models.Model):
 
     delivery_date = fields.Date(
         compute="_compute_delivery_date",
+        store=True,
+        readonly=True,
     )
 
     def _inverse_release_channel_id(self):
@@ -51,13 +53,27 @@ class StockPicking(models.Model):
             all_moves = moves.browse(move_chain_ids)
             all_moves._release_set_expected_date(new_date)
 
-    @api.depends("release_channel_id", "need_release", "partner_id")
+    @api.depends(
+        "release_channel_id",
+        "need_release",
+        "partner_id",
+        "state",
+        "scheduled_date",
+        "date_done",
+    )
     def _compute_delivery_date(self):
         # compute the earliest delivery date from the scheduled date
         for picking in self:
-            channel = picking.release_channel_id
-            if not channel or not picking.partner_id or picking.need_release:
+            if (
+                picking.state == "cancel"
+                or not picking.picking_type_code == "outgoing"
+                or not picking.partner_id
+                or picking.need_release
+            ):
                 picking.delivery_date = False
+                continue
+            channel = picking.release_channel_id
+            if not channel:
                 continue
             # Use the scheduled date as preparation end date
             steps = channel._delivery_date_steps
@@ -66,9 +82,15 @@ class StockPicking(models.Model):
                 if step == "preparation":
                     steps = steps[i + 1 :]
                     break
+            if picking.state == "done":
+                end_preparation_date = picking.date_done
+            else:
+                end_preparation_date = max(
+                    picking.scheduled_date, fields.Datetime.now()
+                )
             delivery_dt = channel._get_earliest_delivery_date(
                 picking.partner_id,
-                picking.scheduled_date,
+                end_preparation_date,
                 steps=steps,
             )
             picking.delivery_date = channel._localize(delivery_dt).date()

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -75,12 +75,14 @@ class StockPicking(models.Model):
                 picking.state == "cancel"
                 or not picking.picking_type_code == "outgoing"
                 or not picking.partner_id
-                or picking.need_release
             ):
-                picking.delivery_date = False
+                if picking.delivery_date:
+                    picking.delivery_date = False
+                continue
+            if picking.need_release:
                 continue
             channels = picking.release_channel_id
-            if not channels:
+            if not channels or channels.state == "asleep":
                 channels = picking._get_partner_release_channels()
             if not channels:
                 continue
@@ -110,7 +112,11 @@ class StockPicking(models.Model):
                     dates.append(channel._localize(delivery_dt).date())
             if not dates:
                 continue
-            picking.delivery_date = min(dates)
+            delivery_date = min(dates)
+            if picking.delivery_date:
+                delivery_date = max(delivery_date, picking.delivery_date)
+            if delivery_date != picking.delivery_date:
+                picking.delivery_date = delivery_date
 
     def _delay_assign_release_channel(self):
         for picking in self:

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -1056,6 +1056,7 @@ class StockReleaseChannel(models.Model):
         return dt
 
     @property
+    @api.model
     def _delivery_date_steps(self):
         """Returns the steps to compute the delivery date."""
         return ["preparation", "delivery", "customer"]

--- a/stock_release_channel/views/stock_picking_views.xml
+++ b/stock_release_channel/views/stock_picking_views.xml
@@ -5,6 +5,9 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <field name="date_deadline">
+                <field name="delivery_date" invisible="not delivery_date or (delivery_date == date_deadline)" />
+            </field>
             <group name="other_infos" position="inside">
                 <field name="release_channel_id" options="{'no_create': True}" />
             </group>

--- a/stock_release_channel/views/stock_picking_views.xml
+++ b/stock_release_channel/views/stock_picking_views.xml
@@ -5,8 +5,11 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-            <field name="date_deadline">
-                <field name="delivery_date" invisible="not delivery_date or (delivery_date == date_deadline)" />
+            <field name="date_deadline" position="after">
+                <field
+                    name="delivery_date"
+                    invisible="not delivery_date or (delivery_date == date_deadline)"
+                />
             </field>
             <group name="other_infos" position="inside">
                 <field name="release_channel_id" options="{'no_create': True}" />


### PR DESCRIPTION
When the transfer is not processed on time, use now for delivery date computation

cc @simahawk 