### PR TITLE
[18.0][FIX] stock_release_channel_partner_delivery_window: fix planned delivery date

### DIFF
--- a/stock_release_channel_partner_delivery_window/models/stock_picking.py
+++ b/stock_release_channel_partner_delivery_window/models/stock_picking.py
@@ -8,7 +8,9 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _planned_delivery_date(self):
-        return self.delivery_date
+        return self.delivery_date or (
+            self.need_release and super()._planned_delivery_date()
+        )
 
     @property
     def _release_channel_possible_candidate_domain_partner_delivery_window(self):


### PR DESCRIPTION
When the delivery is not yet released, the delivery date is not yet set. If the delivery date is not set and the delivery needs release, then return the scheduled date

cc @sebalix @mmequignon 