### PR TITLE
[FIX][18.0] stock_release_channel_process_end_time: fix scheduled_date

### DIFF
--- a/stock_release_channel_process_end_time/models/stock_move.py
+++ b/stock_release_channel_process_end_time/models/stock_move.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import models
+from odoo.tools import str2bool
 
 
 class StockMove(models.Model):
@@ -12,7 +13,7 @@ class StockMove(models.Model):
         if (
             self.picking_id.picking_type_code == "outgoing"
             and self.picking_id.release_channel_id.process_end_date
-            and bool(
+            and str2bool(
                 self.env["ir.config_parameter"]
                 .sudo()
                 .get_param(

--- a/stock_release_channel_process_end_time/models/stock_picking.py
+++ b/stock_release_channel_process_end_time/models/stock_picking.py
@@ -93,25 +93,3 @@ class StockPicking(models.Model):
             operator_inselect = "not in" if operator == "=" else "in"
         sql = SQL(f"({query})", *params)
         return [("id", operator_inselect, sql)]
-
-    def _after_release_set_expected_date(self):
-        enabled_update_scheduled_date = bool(
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param(
-                "stock_release_channel_process_end_time.stock_release_use_channel_end_date"
-            )
-        )
-        res = super()._after_release_set_expected_date()
-        for rec in self:
-            # Check if a channel has been assigned to the picking and write
-            # scheduled_date if different to avoid unnecessary write
-            if (
-                rec.state not in ("done", "cancel")
-                and rec.release_channel_id
-                and rec.release_channel_id.process_end_date
-                and rec.scheduled_date != rec.release_channel_id.process_end_date
-                and enabled_update_scheduled_date
-            ):
-                rec.scheduled_date = rec.release_channel_id.process_end_date
-        return res

--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -111,6 +111,10 @@ class StockReleaseChannel(models.Model):
                 "stock_release_channel_process_end_time.stock_release_use_channel_end_date"
             )
         )
-        if enabled_update_scheduled_date:
+        if (
+            enabled_update_scheduled_date
+            and self.state != "asleep"
+            and self.process_end_date
+        ):
             return self.process_end_date
         return super()._get_expected_date()

--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from odoo import api, fields, models
+from odoo.tools import str2bool
 
 from odoo.addons.base.models.res_partner import _tz_get
 
@@ -104,7 +105,7 @@ class StockReleaseChannel(models.Model):
     def _get_expected_date(self):
         # Use channel process end date
         self.ensure_one()
-        enabled_update_scheduled_date = bool(
+        enabled_update_scheduled_date = str2bool(
             self.env["ir.config_parameter"]
             .sudo()
             .get_param(


### PR DESCRIPTION
Update delivery scheduled date only if the delivery is released in the scope of an ongoing channel and that channel uses a process end date.

Remove dead code. _after_release_set_expected_date is obsolete.

cc @lmignon @rousseldenis @sebalix 