### PR TITLE
[18.0][FIX] stock_release_channel: ensure backorder is assigned a channel

### DIFF
--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -25,12 +25,24 @@ class StockMove(models.Model):
                 moves.picking_id.assign_release_channel()
         return res
 
-    def _action_confirm(self, merge=True, merge_into=False):
-        moves = super()._action_confirm(merge=merge, merge_into=merge_into)
-        pickings = moves.filtered("need_release").picking_id
-        if pickings:
-            pickings._delay_assign_release_channel()
-        return moves
+    def _unreleased_to_backorder(self, split_order=False):
+        if split_order:
+            self = self.with_context(skip_assign_release_channel=True)
+            origin_pickings = self.picking_id
+        res = super()._unreleased_to_backorder(split_order=split_order)
+        if split_order:
+            origin_pickings.filtered(
+                lambda p: p.state not in ("draft", "cancel") and p.need_release
+            )._delay_assign_release_channel()
+        return res
+
+    def _assign_picking_post_process(self, new=False):
+        res = super()._assign_picking_post_process(new=new)
+        if not self.env.context.get("skip_assign_release_channel"):
+            pickings = self.filtered("need_release").picking_id
+            if pickings:
+                pickings._delay_assign_release_channel()
+        return res
 
     def _release_get_expected_date(self):
         """Return the new scheduled date of a single delivery move"""

--- a/stock_release_channel/tests/test_release_channel.py
+++ b/stock_release_channel/tests/test_release_channel.py
@@ -5,11 +5,13 @@ from unittest import mock
 
 from odoo import exceptions
 
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import trap_jobs
 from odoo.addons.stock_release_channel.models.stock_release_channel import (
     StockReleaseChannel,
 )
 
-from .common import ReleaseChannelCase
+from .common import ChannelReleaseCase, ReleaseChannelCase
 
 
 class TestReleaseChannel(ReleaseChannelCase):
@@ -137,3 +139,26 @@ class TestReleaseChannel(ReleaseChannelCase):
         move.quantity = move.product_uom_qty
         move.picking_id._action_done()
         self.assertFalse(self.default_channel.open_picking_ids)
+
+
+class TestChannelRelease(ChannelReleaseCase):
+    def test_backorder_channel(self):
+        delivery = self._out_picking(
+            self._create_picking_chain(
+                self.wh, [(self.product1, 100)], move_type="direct"
+            )
+        )
+        self._update_qty_in_location(self.loc_bin1, self.product1, 80)
+        delivery.move_ids.rule_id.no_backorder_at_release = False
+        with trap_jobs() as trap:
+            delivery.release_available_to_promise()
+            backorder = delivery.backorder_ids
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                backorder.assign_release_channel,
+                args=(),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )


### PR DESCRIPTION
cc @sebalix @lmignon @rousseldenis @mt-software-de 