### PR TITLE
[18.0][FIX] stock_release_channel_shipment_lead_time: shipment date

### DIFF
--- a/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
@@ -49,7 +49,13 @@ class StockReleaseChannel(models.Model):
         if not self.delivery_calendar_id:
             shipment_tz = fields.Datetime.add(dt_tz, days=self.shipment_lead_time)
         else:
-            days = self.shipment_lead_time + 1
+            days = self.shipment_lead_time
+            if days:
+                # We consider the current day as valid, we add a day, and then
+                # we look for open days for the given delay. Reset time to 0 in
+                # case the end time if after the warehouse calendar end time.
+                dt_tz = fields.Datetime.add(dt_tz, days=1)
+                dt_tz = dt_tz.replace(hour=0, minute=0, second=0, microsecond=0)
             shipment_tz = self.delivery_calendar_id.plan_days(
                 days, dt_tz, compute_leaves=True
             )

--- a/stock_release_channel_shipment_lead_time/tests/test_release_shipment_date.py
+++ b/stock_release_channel_shipment_lead_time/tests/test_release_shipment_date.py
@@ -2,6 +2,11 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import datetime
+
+import pytz
+from freezegun import freeze_time
+
 from odoo import fields
 
 from odoo.addons.stock_release_channel.tests.common import ChannelReleaseCase
@@ -20,18 +25,106 @@ class TestChannelReleaseShipmentLeadTime(ChannelReleaseCase):
             fields.Date.to_string(self.channel.shipment_date),
         )
 
-    def test_shipment_date_with_calendar(self):
+    def _test_shipment_date_with_calendar(self):
+        # DST ends on 2025-10-26
         self.channel.warehouse_id = self.wh
+        self.channel.warehouse_id.partner_id.tz = "Europe/Brussels"
+        wh_tz = pytz.timezone(self.channel.warehouse_id.partner_id.tz)
         self.channel.warehouse_id.calendar_id = self.env.ref(
             "resource.resource_calendar_std"
         )
-        self.channel.process_end_time = 12
-        self.channel.process_end_date = "2023-06-30"
-        self.channel.shipment_lead_time = 6
+        self.channel.process_end_date = "2025-10-20 12:00:00"
+        self.channel.shipment_lead_time = 1
         self.assertEqual(
-            "2023-07-10",
+            "2025-10-21",
             fields.Date.to_string(self.channel.shipment_date),
         )
+        # Dates with DST
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 20, 0, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-21",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 20, 23, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-21",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 17, 0, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-20",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 17, 23, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-20",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        # Dates over DST
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 24, 00, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-27",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 24, 23, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-27",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        # Dates without DST
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 27, 0, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-28",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 27, 23, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-10-28",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 31, 0, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-11-03",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+        local_dt = wh_tz.localize(datetime.datetime(2025, 10, 31, 23, 30))
+        self.channel.process_end_date = self.channel._naive(local_dt)
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(
+            "2025-11-03",
+            fields.Date.to_string(self.channel.shipment_date),
+        )
+
+    @freeze_time("2025-10-20")
+    def test_shipment_date_with_calendar_dst(self):
+        """Test when we are in DST"""
+        self._test_shipment_date_with_calendar()
+
+    @freeze_time("2025-10-27")
+    def test_shipment_date_with_calendar_nodst(self):
+        """Test when we are without DST
+
+        Dates should be the same. Current date shouldn't have an impact.
+        """
+        self._test_shipment_date_with_calendar()
 
     def test_delivery_date_shipment_lead_time(self):
         self.channel.warehouse_id = self.wh


### PR DESCRIPTION
Fix shipment date when the end date is after the calendar opening time

cc @mmequignon 