### PR TITLE
[18.0][IMP] stock_release_channel_process_end_date

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -12,7 +12,7 @@ from operator import itemgetter
 import pytz
 
 from odoo import api, exceptions, fields, models
-from odoo.osv.expression import NEGATIVE_TERM_OPERATORS
+from odoo.osv.expression import AND, NEGATIVE_TERM_OPERATORS
 from odoo.tools import groupby
 from odoo.tools.safe_eval import (
     datetime as safe_datetime,
@@ -320,18 +320,23 @@ class StockReleaseChannel(models.Model):
             ("need_release", "=", True),
         ]
 
+    @property
+    def _field_picking_domain_release_ready_extra(self):
+        # Allow stock_release_channel_process_end_time to restrict domain based
+        # on scheduled date
+        return []
+
     def _field_picking_domains(self):
         return {
             "all": [],
-            "release_ready": [
-                ("release_ready", "=", True),
-                # FIXME not TZ friendly
-                (
-                    "scheduled_date",
-                    "<",
-                    fields.Datetime.now().replace(hour=23, minute=59),
-                ),
-            ],
+            "release_ready": AND(
+                [
+                    [
+                        ("release_ready", "=", True),
+                    ],
+                    self._field_picking_domain_release_ready_extra,
+                ]
+            ),
             "released": [
                 ("last_release_date", "!=", False),
                 ("state", "in", ("assigned", "waiting", "confirmed")),

--- a/stock_release_channel_process_end_time/models/stock_picking.py
+++ b/stock_release_channel_process_end_time/models/stock_picking.py
@@ -1,16 +1,16 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.osv.expression import AND
 from odoo.tools import SQL
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    # TODO: move this field to stock_release_channel so that we don't have to alter
-    # _field_picking_domains.
     scheduled_date_prior_to_channel_end_date_search = fields.Boolean(
         store=False,
         search="_search_scheduled_date_prior_to_channel_end_date",
@@ -115,3 +115,17 @@ class StockPicking(models.Model):
             ):
                 rec.scheduled_date = rec.release_channel_id.process_end_date
         return res
+
+    @property
+    def _release_channel_possible_candidate_domain_base(self):
+        domain = super()._release_channel_possible_candidate_domain_base
+        wh_tz = self.picking_type_id.warehouse_id.partner_id.tz or "UTC"
+        channel = self.env["stock.release.channel"]
+        delivery_date_tz = channel._localize(self.scheduled_date, tz=wh_tz)
+        delivery_date = channel._naive(delivery_date_tz, reset_time=True)
+        domain_scheduled_date = [
+            "|",
+            ("process_end_date", "=", False),
+            ("process_end_date", ">", delivery_date),
+        ]
+        return AND([domain, domain_scheduled_date])

--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from odoo import api, fields, models
+from odoo.osv.expression import AND
 
 from odoo.addons.base.models.res_partner import _tz_get
 
@@ -75,31 +76,26 @@ class StockReleaseChannel(models.Model):
                 channel.warehouse_id.partner_id.tz or company_tz or "UTC"
             )
 
-    def _field_picking_domains(self):
-        res = super()._field_picking_domains()
-        release_ready_domain = res["release_ready"]
-        # the initial scheduled_date condition based on datetime.now() must
-        # be replaced by a condition based on the process_end_date
-        # since the processe_end_date is a field on the release channel
-        # and not on the picking we all use an 'inselect' operator
-        # (join in where clause is not possible). The 'inselect' operator
-        # is not available in the ORM so we use a search with a domain
-        # on a specialized field defined in the stock.picking model
-        # (see stock.picking._search_schedule_date_prior_to_channel_process_end_date)
-        new_domain = []
-        for criteria in release_ready_domain:
-            if criteria[0] == "scheduled_date":
-                new_domain.append(
-                    (
-                        "scheduled_date_prior_to_channel_end_date_search",
-                        "=",
-                        True,
-                    )
-                )
-            else:
-                new_domain.append(criteria)
-        res["release_ready"] = new_domain
-        return res
+    @property
+    def _field_picking_domain_release_ready_extra(self):
+        domain = super()._field_picking_domain_release_ready_extra
+        if len(self) != 1:
+            domain_scheduled_date = [
+                "scheduled_date_prior_to_channel_end_date_search",
+                "=",
+                True,
+            ]
+            domain = AND([domain, domain_scheduled_date])
+        elif self.process_end_date:
+            wh_tz = self.process_end_time_tz
+            end_date_tz = self._localize(self.process_end_date, tz=wh_tz)
+            end_date_tomorrow_tz = fields.Datetime.add(end_date_tz, days=1)
+            end_date_tomorrow = self._naive(end_date_tomorrow_tz, reset_time=True)
+            domain_scheduled_date = [
+                ("scheduled_date", "<", end_date_tomorrow),
+            ]
+            domain = AND([domain, domain_scheduled_date])
+        return domain
 
     def _get_expected_date(self):
         # Use channel process end date

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -70,17 +70,31 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         jobs_before = self.env["queue.job"].search([])
         jobs_before.unlink()
         # Set the end time
-        self.channel.process_end_time = 23.0
+        self.channel.process_end_time = 9.0
         # Set picking scheduled date
-        pickings = self.picking | self.picking2 | self.picking3
-        pickings.write({"scheduled_date": fields.Datetime.now()})
+        # picking = today
+        # picking2 = tomorrow
+        # picking3 = in 2 days
+        self.picking.scheduled_date = fields.Datetime.now()
+        self.picking2.scheduled_date = fields.Datetime.add(
+            fields.Datetime.now(), days=1
+        )
+        self.picking3.scheduled_date = fields.Datetime.add(
+            fields.Datetime.now(), days=2
+        )
 
         # Asleep the release channel to void the process end date
         self.channel.action_sleep()
         self.channel.invalidate_recordset()
         # Execute the picking channel assignations
         self.channel.with_context(queue_job__no_delay=True).action_wake_up()
-
+        self.assertEqual(
+            "2023-01-28 09:00:00",
+            fields.Datetime.to_string(self.channel.process_end_date),
+        )
+        # Check deliveries planned after channel process end date end of day
+        # are not assigned to the channel
+        pickings = self.picking | self.picking2
         self.assertEqual(pickings, self.channel.picking_ids)
         # at this stage, the pickings are not ready to be released as the
         # qty available is not enough
@@ -92,11 +106,11 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.assertEqual(pickings, self.channel._get_pickings_to_release())
         # if the scheduled date of one picking is changed to be on a time after the
         # process end date but on the same day, it should still be releasable
-        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-27 23:30:00")
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-28 23:30:00")
         self.assertEqual(pickings, self.channel._get_pickings_to_release())
         # if the scheduled date of one picking is changed to be on a date after the
         # process end date, it should not be releasable anymore
-        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-28 00:00:00")
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-29 00:00:00")
         self.assertEqual(pickings[1:], self.channel._get_pickings_to_release())
 
     @freeze_time("2023-01-27 10:00:00")
@@ -114,7 +128,9 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.channel.action_sleep()
         self.channel.invalidate_recordset()
         # Execute the picking channel assignations
+        self.picking.scheduled_date = fields.Datetime.now()
         self.channel.with_context(queue_job__no_delay=True).action_wake_up()
+        self.assertEqual(self.picking.release_channel_id, self.channel)
         for picking in self.channel.picking_ids:
             self.assertNotEqual(
                 "2023-01-27 23:00:00", fields.Datetime.to_string(picking.scheduled_date)
@@ -181,14 +197,12 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         # Asleep the release channel to void the process end date
         # The first call to `action_sleep` ensures the channel is set to 'asleep' state,
         # which prevents pickings from being assigned immediately.
-        # We expect a warning on this transition, hence the log assertion.
         # When other active channels exist, pickings could otherwise be reassigned to
         # them. By sleeping this channel and ensuring no reassignment happens,
         # we preserve the pickings in an unassigned state.
         # Upon calling `action_wake_up`, the channel wakes up and reassigns the pending
         # pickings.
-        with self.assertLogs(level="WARNING"):
-            channel.action_sleep()
+        channel.action_sleep()
         new_pickings = channel.picking_ids.move_ids.move_orig_ids.picking_id
         self.assertFalse(new_pickings)
         channel.invalidate_recordset()


### PR DESCRIPTION
* stock_release_channel : Do not prevent to release a delivery planned after today. Use stock_release_channel_process_end_date to set an explicit date limit
* stock_release_channel_process_end_date : Do not assign deliveries planned after the end date