### PR TITLE
[18.0][FIX] stock_release_channel: candidate selection

### DIFF
--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -141,11 +141,7 @@ class StockPicking(models.Model):
         log = self.env.context.get("assign_release_channel_log_stream")
         if log:
             log.write(f"Find possible channels domain: {domain}\n")
-        return (
-            self.env["stock.release.channel"]
-            .search(domain)
-            .sorted(key=lambda r: (not bool(r.partner_ids), r.sequence))
-        )
+        return self.env["stock.release.channel"].search(domain)
 
     @property
     def _release_channel_possible_candidate_domain(self):

--- a/stock_release_channel/tests/test_release_channel_partner.py
+++ b/stock_release_channel/tests/test_release_channel_partner.py
@@ -11,12 +11,12 @@ class ReleaseChannelPartnerCommon(ReleaseChannelCase):
         cls.partner = cls.env["res.partner"].create({"name": "partner"})
         cls.partner_channel = cls._create_channel(
             name="partner channel",
-            sequence=20,
+            sequence=10,
             code="pickings = pickings.filtered(lambda p: p.priority == '1')",
         )
         cls.other_channel = cls._create_channel(
             name="Test Domain",
-            sequence=10,
+            sequence=20,
             rule_domain=[("priority", "=", "1")],
         )
         cls.move = cls._create_single_move(cls.product1, 10)


### PR DESCRIPTION
Use default sorting of channels. When there is a process_end_date, it is sorting by that date by default.

It reverts this change https://github.com/OCA/wms/pull/651/files#diff-2a4125c4c4c1f2ef83b4dce865797265e4a95a0017d048cb2dfe13c5a868c4fbR76

cc @sebalix @rousseldenis 