### PR TITLE
[18.0][IMP] stock_release_channel: collect pickings

### DIFF
--- a/stock_release_channel/__manifest__.py
+++ b/stock_release_channel/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Release Channels",
     "summary": "Manage workload in WMS with release channels",
-    "version": "18.0.1.3.2",
+    "version": "18.0.1.4.0",
     "development_status": "Beta",
     "license": "AGPL-3",
     "author": "Camptocamp, BCIM, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/stock_release_channel/demo/stock_release_channel.xml
+++ b/stock_release_channel/demo/stock_release_channel.xml
@@ -5,5 +5,6 @@
         <field name="sequence">999</field>
         <field name="rule_domain">[]</field>
         <field name="state">open</field>
+        <field name="collect_pickings" eval="True" />
     </record>
 </odoo>

--- a/stock_release_channel/migrations/18.0.1.4.0/post-migration.py
+++ b/stock_release_channel/migrations/18.0.1.4.0/post-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["stock.release.channel"].search(
+        [
+            ("state", "in", ("open", "locked")),
+        ]
+    ).collect_pickings = True

--- a/stock_release_channel/migrations/18.0.1.4.0/pre-migration.py
+++ b/stock_release_channel/migrations/18.0.1.4.0/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+
+from odoo.tools.sql import column_exists
+
+
+def migrate(cr, version):
+    if not column_exists(
+        cr, "stock_release_channel", "recompute_channel_on_pickings_at_release"
+    ) and column_exists(cr, "res_company", "recompute_channel_on_pickings_at_release"):
+        cr.execute(
+            """
+            ALTER TABLE stock_release_channel ADD COLUMN
+            recompute_channel_on_pickings_at_release boolean;
+
+            UPDATE stock_release_channel
+            SET recompute_channel_on_pickings_at_release =
+            res_company.recompute_channel_on_pickings_at_release
+            FROM res_company
+            WHERE res_company.id = stock_release_channel.company_id;
+            """
+        )

--- a/stock_release_channel/models/res_company.py
+++ b/stock_release_channel/models/res_company.py
@@ -12,7 +12,3 @@ class ResCompany(models.Model):
         help="In release channels dashboard, add link to last done picking "
         "and show transfer date",
     )
-    recompute_channel_on_pickings_at_release = fields.Boolean(
-        help="When releasing a transfer, recompute channel",
-        default=True,
-    )

--- a/stock_release_channel/models/res_config_settings.py
+++ b/stock_release_channel/models/res_config_settings.py
@@ -11,7 +11,3 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.release_channel_show_last_picking_done",
         readonly=False,
     )
-    recompute_channel_on_pickings_at_release = fields.Boolean(
-        related="company_id.recompute_channel_on_pickings_at_release",
-        readonly=False,
-    )

--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -2,10 +2,8 @@
 # Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from operator import itemgetter
 
 from odoo import models
-from odoo.tools import groupby
 
 
 class StockMove(models.Model):
@@ -19,10 +17,9 @@ class StockMove(models.Model):
         # As moves can be merged (and then unlinked), we should ensure
         # they still exist.
         moves = self.exists()
-        for company, imoves in groupby(moves, key=itemgetter("company_id")):
-            if company.recompute_channel_on_pickings_at_release:
-                moves = self.env["stock.move"].concat(*imoves)
-                moves.picking_id.assign_release_channel()
+        for picking in moves.picking_id:
+            if picking.release_channel_id.recompute_channel_on_pickings_at_release:
+                picking.assign_release_channel()
         return res
 
     def _unreleased_to_backorder(self, split_order=False):

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -153,8 +153,7 @@ class StockPicking(models.Model):
         self.ensure_one()
         domain_base = self._release_channel_possible_candidate_domain_base
         domain = [
-            ("is_manual_assignment", "=", False),
-            ("state", "in", ("open", "locked")),
+            ("collect_pickings", "=", True),
             "|",
             ("picking_type_ids", "=", False),
             ("picking_type_ids", "in", self.picking_type_id.ids),

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -51,6 +51,12 @@ class StockReleaseChannel(models.Model):
 
     name = fields.Char(required=True)
     release_forbidden = fields.Boolean(string="Forbid to release this channel")
+    recompute_channel_on_pickings_at_release = fields.Boolean(
+        help="When releasing a transfer, recompute the channel. Be carefull "
+        "when using this in conjuction with channel lifecycle (stop/start "
+        "collecting, sleep/wake up) as a delivery could be kicked out of a "
+        "channel if you stop collecting and recompute after release",
+    )
     sequence = fields.Integer(default=lambda self: self._default_sequence())
     color = fields.Integer()
     company_id = fields.Many2one(

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -202,13 +202,16 @@ class StockReleaseChannel(models.Model):
     )
     last_done_picking_name = fields.Char(compute="_compute_last_done_picking")
     last_done_picking_date_done = fields.Datetime(compute="_compute_last_done_picking")
+    collect_pickings = fields.Boolean(
+        compute="_compute_collect_pickings",
+        store=True,
+        help="Allows you to control if pickings are assigned to the release channel.",
+    )
     state = fields.Selection(
         selection=[("open", "Open"), ("locked", "Locked"), ("asleep", "Asleep")],
         help="The state allows you to control the availability of the release channel."
-        "\n * Open: Manual and automatic picking assignment to the release is effective"
-        " and release operations are allowed.\n"
-        "* Locked: Release operations are forbidden. (Assignement processes are "
-        "still working)\n"
+        "\n * Open: Release operations are allowed.\n"
+        "* Locked: Release operations are forbidden.\n"
         "* Asleep: Assigned pickings not processed are unassigned from the release "
         "channel.\n",
         default="asleep",
@@ -226,6 +229,14 @@ class StockReleaseChannel(models.Model):
     is_action_unlock_allowed = fields.Boolean(
         compute="_compute_is_action_unlock_allowed",
         help="Technical field to check if the " "action 'Unlock' is allowed.",
+    )
+    is_action_collect_restart_allowed = fields.Boolean(
+        compute="_compute_is_action_collect_restart_allowed",
+        help="Technical field to check if the " "action 'Collect Restart' is allowed.",
+    )
+    is_action_collect_stop_allowed = fields.Boolean(
+        compute="_compute_is_action_collect_stop_allowed",
+        help="Technical field to check if the " "action 'Collect Stop' is allowed.",
     )
     is_action_sleep_allowed = fields.Boolean(
         compute="_compute_is_action_sleep_allowed",
@@ -255,6 +266,32 @@ class StockReleaseChannel(models.Model):
     )
     is_manual_assignment = fields.Boolean("Manual assignment")
 
+    @property
+    def _valid_states_for_collect_pickings(self):
+        return ("open", "locked")
+
+    @api.depends("state", "is_manual_assignment")
+    def _compute_collect_pickings(self):
+        for rec in self:
+            if (
+                rec.state not in rec._valid_states_for_collect_pickings
+                or rec.is_manual_assignment
+            ):
+                rec.collect_pickings = False
+
+    @api.constrains("collect_pickings")
+    def _check_collect_pickings(self):
+        for rec in self:
+            if rec.collect_pickings:
+                if rec.state not in rec._valid_states_for_collect_pickings:
+                    raise exceptions.ValidationError(
+                        self.env._("You cannot collect pickings with current state!")
+                    )
+                if rec.is_manual_assignment:
+                    raise exceptions.ValidationError(
+                        self.env._("This channel is restricted for manual assignment!")
+                    )
+
     @api.depends("state")
     def _compute_is_action_lock_allowed(self):
         for rec in self:
@@ -264,6 +301,20 @@ class StockReleaseChannel(models.Model):
     def _compute_is_action_unlock_allowed(self):
         for rec in self:
             rec.is_action_unlock_allowed = rec.state == "locked"
+
+    @api.depends("state")
+    def _compute_is_action_collect_restart_allowed(self):
+        for rec in self:
+            rec.is_action_collect_restart_allowed = (
+                not rec.collect_pickings
+                and rec.state in rec._valid_states_for_collect_pickings
+                and not rec.is_manual_assignment
+            )
+
+    @api.depends("state")
+    def _compute_is_action_collect_stop_allowed(self):
+        for rec in self:
+            rec.is_action_collect_stop_allowed = rec.collect_pickings
 
     @api.depends("state")
     def _compute_is_action_sleep_allowed(self):
@@ -878,6 +929,26 @@ class StockReleaseChannel(models.Model):
                     )
                 )
 
+    def _check_is_action_collect_restart_allowed(self):
+        for rec in self:
+            if not rec.is_action_collect_restart_allowed:
+                raise exceptions.UserError(
+                    self.env._(
+                        "Action 'Collect Restart' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
+    def _check_is_action_collect_stop_allowed(self):
+        for rec in self:
+            if not rec.is_action_collect_stop_allowed:
+                raise exceptions.UserError(
+                    self.env._(
+                        "Action 'Collect Stop' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
     def _check_is_action_sleep_allowed(self):
         for rec in self:
             if not rec.is_action_sleep_allowed:
@@ -906,6 +977,19 @@ class StockReleaseChannel(models.Model):
         self._check_is_action_unlock_allowed()
         self.write({"state": "open"})
 
+    def action_collect_restart(self):
+        self._check_is_action_collect_restart_allowed()
+        self.collect_pickings = True
+        self.assign_pickings()
+
+    def action_collect_stop(self):
+        self._check_is_action_collect_stop_allowed()
+        self.collect_pickings = False
+        in_need_release = self.picking_ids.filtered("need_release")
+        to_unassign = in_need_release.filtered(lambda p: not p.release_ready)
+        to_unassign.release_channel_id = False
+        to_unassign._delay_assign_release_channel()
+
     def action_sleep(self):
         self._check_is_action_sleep_allowed()
         pickings_to_unassign = self.env["stock.picking"].search(
@@ -913,13 +997,23 @@ class StockReleaseChannel(models.Model):
         )
         pickings_to_unassign.write({"release_channel_id": False})
         pickings_to_unassign.unrelease()
-        self.write({"state": "asleep"})
+        self.write(
+            {
+                "state": "asleep",
+                "collect_pickings": False,
+            }
+        )
         pickings_to_unassign._delay_assign_release_channel()
 
     def action_wake_up(self):
         self._check_is_action_wake_up_allowed()
         for rec in self:
-            rec.state = rec.state_at_wakeup
+            rec.write(
+                {
+                    "state": rec.state_at_wakeup,
+                    "collect_pickings": True,
+                }
+            )
         self.assign_pickings()
 
     @api.model

--- a/stock_release_channel/tests/common.py
+++ b/stock_release_channel/tests/common.py
@@ -116,7 +116,7 @@ class ReleaseChannelCase(common.TransactionCase):
     @classmethod
     def _create_channel(cls, **vals):
         # Forced update state of channel to "open"
-        vals.update({"state": "open"})
+        vals.update({"state": "open", "collect_pickings": True})
         return cls.env["stock.release.channel"].create(vals)
 
     def _run_customer_procurement(self, date=None):

--- a/stock_release_channel/tests/test_release_channel.py
+++ b/stock_release_channel/tests/test_release_channel.py
@@ -122,11 +122,10 @@ class TestReleaseChannel(ReleaseChannelCase):
         move.picking_id.priority = "1"  # To find new suitable channel for this picking
 
         # Test with recompute_channel_on_pickings_at_release = False
-        self.env.company.recompute_channel_on_pickings_at_release = False
         move.release_available_to_promise()
         self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
         # Test with recompute_channel_on_pickings_at_release = False
-        self.env.company.recompute_channel_on_pickings_at_release = True
+        self.default_channel.recompute_channel_on_pickings_at_release = True
         move.release_available_to_promise()
         self.assertEqual(move.picking_id.release_channel_id, channel)
 

--- a/stock_release_channel/tests/test_release_channel.py
+++ b/stock_release_channel/tests/test_release_channel.py
@@ -106,6 +106,7 @@ class TestReleaseChannel(ReleaseChannelCase):
         self.assertEqual(move.picking_id.release_channel_id.id, False)
         # Automatic Assignment
         self.default_channel.is_manual_assignment = False
+        self.default_channel.collect_pickings = True
         move = self._create_single_move(self.product1, 10)
         move.picking_id.assign_release_channel()
         self.assertEqual(move.picking_id.release_channel_id.id, self.default_channel.id)

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -47,12 +47,52 @@ class TestReleaseChannelLifeCycle(ReleaseChannelCase):
         move.picking_id.assign_release_channel()
         self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
         copy_channel = self.default_channel.copy(
-            {"name": "channel copy", "state": "open"}
+            {"name": "channel copy", "state": "open", "collect_pickings": True}
         )
         with trap_jobs() as trap:
             self.default_channel.action_sleep()
             trap.perform_enqueued_jobs()
         self.assertEqual(move.picking_id.release_channel_id, copy_channel)
+
+    def test_release_channel_collect_stop_unassign(self):
+        move = self._create_single_move(self.product1, 10)
+        move.need_release = True
+        move.picking_id.release_channel_id = self.default_channel
+        self.assertTrue(self.default_channel.collect_pickings)
+        self.assertFalse(move.picking_id.release_ready)
+        with trap_jobs() as trap:
+            self.default_channel.action_collect_stop()
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                move.picking_id.assign_release_channel,
+                args=(),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            trap.enqueued_jobs[0].perform()
+        self.assertFalse(move.picking_id.release_channel_id)
+
+    def test_release_channel_collect_restart_assign(self):
+        self.default_channel.collect_pickings = False
+        move = self._create_single_move(self.product1, 10)
+        move.need_release = True
+        self.assertFalse(move.picking_id.release_channel_id)
+        with trap_jobs() as trap:
+            self.default_channel.action_collect_restart()
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                move.picking_id.assign_release_channel,
+                args=(),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            trap.enqueued_jobs[0].perform()
+        self.assertTrue(self.default_channel.collect_pickings)
+        self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
 
     def test_release_channel_wake_up_assign(self):
         self.default_channel.action_sleep()

--- a/stock_release_channel/views/res_config_settings.xml
+++ b/stock_release_channel/views/res_config_settings.xml
@@ -17,13 +17,6 @@
                         Show last delivery done in release channels dashboard
                     </div>
                 </setting>
-
-                <setting name="recompute_channel_on_pickings_at_release">
-                    <field name="recompute_channel_on_pickings_at_release" />
-                    <div class="text-muted">
-                        Recompute channel when releasing a transfer
-                    </div>
-                </setting>
             </xpath>
         </field>
     </record>

--- a/stock_release_channel/views/stock_release_channel_views.xml
+++ b/stock_release_channel/views/stock_release_channel_views.xml
@@ -23,6 +23,22 @@
                         invisible="not is_action_unlock_allowed"
                     />
                     <button
+                        name="action_collect_restart"
+                        string="Restart Collecting"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-hourglass-start"
+                        invisible="not is_action_collect_restart_allowed"
+                    />
+                    <button
+                        name="action_collect_stop"
+                        string="Stop Collecting"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-stop-circle"
+                        invisible="not is_action_collect_stop_allowed"
+                    />
+                    <button
                         name="action_sleep"
                         string="Sleep"
                         type="object"
@@ -248,7 +264,14 @@
                 <field name="count_picking_chain" />
                 <field name="show_last_picking_done" />
                 <field name="state" />
+                <field name="collect_pickings" />
                 <field name="is_release_allowed" />
+                <field name="is_action_lock_allowed" />
+                <field name="is_action_unlock_allowed" />
+                <field name="is_action_collect_restart_allowed" />
+                <field name="is_action_collect_stop_allowed" />
+                <field name="is_action_sleep_allowed" />
+                <field name="is_action_wake_up_allowed" />
                 <templates>
                     <t t-name="menu">
                         <div class="container o_kanban_card_manage_pane">
@@ -256,22 +279,6 @@
                                 <div
                                     class="col-6 o_kanban_card_manage_section o_kanban_manage_view"
                                 >
-                                    <field
-                                        name="is_action_lock_allowed"
-                                        invisible="1"
-                                    />
-                                    <field
-                                        name="is_action_unlock_allowed"
-                                        invisible="1"
-                                    />
-                                    <field
-                                        name="is_action_sleep_allowed"
-                                        invisible="1"
-                                    />
-                                    <field
-                                        name="is_action_wake_up_allowed"
-                                        invisible="1"
-                                    />
                                     <div
                                         role="menuitem"
                                         class="o_kanban_card_manage_title"
@@ -297,6 +304,36 @@
                                                 icon="fa-unlock"
                                             >
                                                 <span class="ms-2">Unlock</span>
+                                            </a>
+                                        </div>
+                                    </t>
+                                    <t
+                                        t-if="record.is_action_collect_restart_allowed.raw_value"
+                                    >
+                                        <div role="menuitem">
+                                            <a
+                                                name="action_collect_restart"
+                                                type="object"
+                                                icon="fa-hourglass-start"
+                                            >
+                                                <span
+                                                    class="ms-2"
+                                                >Restart Collecting</span>
+                                            </a>
+                                        </div>
+                                    </t>
+                                    <t
+                                        t-if="record.is_action_collect_stop_allowed.raw_value"
+                                    >
+                                        <div role="menuitem">
+                                            <a
+                                                name="action_collect_stop"
+                                                type="object"
+                                                icon="fa-stop-circle"
+                                            >
+                                                <span
+                                                    class="ms-2"
+                                                >Stop Collecting</span>
                                             </a>
                                         </div>
                                     </t>
@@ -357,7 +394,12 @@
                                     <div class="o_kanban_card_header_title">
                                         <div class="o_primary">
                                             <field name="name" />
-                                            <field name="state" invisible="1" />
+                                            <i
+                                                t-attf-class="fa {{ record.collect_pickings.raw_value and 'fa-hourglass-start' or 'fa-stop-circle' }}"
+                                                role="img"
+                                                title="collect pickings"
+                                                style="float: right; margin-right: 14px; line-height: 24px"
+                                            />
                                             <t
                                                 t-set="classname"
                                                 t-value="{'open': 'fa fa-unlock', 'locked': 'fa fa-lock', 'asleep': 'fa fa-bed'}[record.state.raw_value] || ''"
@@ -366,7 +408,7 @@
                                                 t-attf-class="{{ classname }}"
                                                 role="img"
                                                 title="state"
-                                                style="float: right; margin-right: 14px; line-height: 24px"
+                                                style="float: right; margin-right: 8px; line-height: 24px"
                                             />
                                         </div>
                                     </div>

--- a/stock_release_channel/views/stock_release_channel_views.xml
+++ b/stock_release_channel/views/stock_release_channel_views.xml
@@ -111,6 +111,9 @@
                                 <field name="state_at_wakeup" />
                                 <field name="release_forbidden" />
                                 <field
+                                    name="recompute_channel_on_pickings_at_release"
+                                />
+                                <field
                                     name="release_mode"
                                     invisible="release_forbidden"
                                 />

--- a/stock_release_channel_cutoff/__manifest__.py
+++ b/stock_release_channel_cutoff/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Release Channels Cutoff",
     "summary": "Add the cutoff time to the release channel",
-    "version": "18.0.1.0.3",
+    "version": "18.0.1.1.0",
     "license": "AGPL-3",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "maintainers": ["jbaudoux"],

--- a/stock_release_channel_cutoff/models/stock_release_channel.py
+++ b/stock_release_channel_cutoff/models/stock_release_channel.py
@@ -41,7 +41,7 @@ class StockReleaseChannel(models.Model):
         now = fields.Datetime.now()
         for channel in self:
             cutoff_warning = False
-            if channel.state == "open" and channel.cutoff_time:
+            if channel.collect_pickings and channel.cutoff_time:
                 cutoff_warning = channel.cutoff_datetime(channel.process_end_date) < now
             channel.cutoff_warning = cutoff_warning
 

--- a/stock_release_channel_partner_address/__manifest__.py
+++ b/stock_release_channel_partner_address/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Release Channels - Partner Address",
     "summary": "Allows defining countries and states filters on channels",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.0",
     "development_status": "Beta",
     "license": "AGPL-3",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",

--- a/stock_release_channel_partner_address/tests/test_release_channel_partner_address.py
+++ b/stock_release_channel_partner_address/tests/test_release_channel_partner_address.py
@@ -38,6 +38,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [],
                 "state_ids": [],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.channel_it = cls.env["stock.release.channel"].create(
@@ -46,6 +47,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [(4, cls.italy.id)],
                 "state_ids": [],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.channel_uk = cls.env["stock.release.channel"].create(
@@ -56,6 +58,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [(4, cls.env.ref("base.uk").id)],
                 "state_ids": [],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.channel_it_an = cls.env["stock.release.channel"].create(
@@ -64,6 +67,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [(4, cls.italy.id)],
                 "state_ids": [(4, cls.ancona.id)],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.channel_it_rm = cls.env["stock.release.channel"].create(
@@ -74,6 +78,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [(4, cls.italy.id)],
                 "state_ids": [(4, cls.roma.id)],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.channel_it_an_rm = cls.env["stock.release.channel"].create(
@@ -84,6 +89,7 @@ class TestReleaseChannelPartnerAddress(ReleaseChannelCase):
                 "country_ids": [(4, cls.italy.id)],
                 "state_ids": [(4, cls.ancona.id), (4, cls.roma.id)],
                 "state": "open",
+                "collect_pickings": True,
             }
         )
         cls.all_channels = (


### PR DESCRIPTION
Allow to stop collecting pickings in a release channel. Non releasable deliveries are removed from the release channel and a job is spawn to try to reassign them to another channel.

At some point in time (typically when the cutoff is reached), you want to stop having new deliveries to release. Up to now, the only way was to sleep the release channel. However, you cannot do that when there is still released work to process. You need to process the "To Do" pickings & deliveries.
During this time, backorders could become available (thanks to goods reception) and generate more work to release. 
Also, if there is another channel in the future that allows to process the delivery, you may prefer to forward the delivery to that channel. In the current channel, you may not have the time to process the released work.

<img width="766" height="306" alt="image" src="https://github.com/user-attachments/assets/6836b134-8b3b-4c4b-a89b-628732c2b26a" />

New actions:
* Stop Collecting
* Restart Collecting

cc @sebalix @Highcooley @rousseldenis @lmignon @mt-software-de @phschmidt 