### PR TITLE
[18.0][IMP] stock_release_channel: prefetch data before release

### DIFF
--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -71,6 +71,10 @@ class StockPicking(models.Model):
                     )
                     % channel.name
                 )
+        # Prefetches move_orig_ids data, to avoid a parallel bitmap heap scan
+        # triggered by _inverse_release_channel_id, while getting origin moves
+        # matching the company.
+        self.move_ids.move_orig_ids.mapped("state")
         return super().release_available_to_promise()
 
     def _create_backorder(self, backorder_moves=None):


### PR DESCRIPTION
while `release_available_to_promise` is being executed, release_channel_id is set on stock pickings, which triggers an inverse method setting expected_date on the whole chain of moves.

For each picking, it would execute the same sql query, which is takes a lot of time mapping `stock_move_move_rel` with `stock_move.company_id`.

In order to fix that, fetch data in the cache before calling super() in the override of release_available_to_promise().

Here are some speedscope screenshots (sorry, I prefer avoiding sharing the json data)

Before (took ~46s)
<img width="3425" height="1188" alt="image" src="https://github.com/user-attachments/assets/c94c80e6-de6c-490d-acae-35fd0d6c6b8d" />

After (took ~3s)
<img width="3422" height="1516" alt="image" src="https://github.com/user-attachments/assets/8819a858-816e-48f8-bca3-1bdb4a510f42" />
