### PR TITLE
[18.0][FIX] stock_release_channel: ensure channel

### DIFF
--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -98,6 +98,11 @@ class StockPicking(models.Model):
     def release_available_to_promise(self):
         for record in self:
             channel = record.release_channel_id
+            if not channel:
+                # When releasing a delivery not part of a channel (the job may
+                # not have run yet), try first to assign a channel
+                channel.assign_release_channel(record)
+                channel = record.release_channel_id
             if channel.release_forbidden:
                 raise exceptions.UserError(
                     self.env._(


### PR DESCRIPTION
On release, try to assign a channel if not part of one