### PR TITLE
[18.0][FIX] stock_release_channel: remove warning when no channel found

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -684,7 +684,6 @@ class StockReleaseChannel(models.Model):
             message_template = (
                 "Transfer %(picking_name)s could not be assigned to a channel"
             )
-            _logger.warning(message_template, {"picking_name": picking.name})
             message = self.env._(message_template, picking_name=picking.name)
         return message
 

--- a/stock_release_channel_partner_delivery_window/tests/test_release_window.py
+++ b/stock_release_channel_partner_delivery_window/tests/test_release_window.py
@@ -81,10 +81,8 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.picking.partner_id = self.customer_working_days
         # Since the channel's end date falls on a Saturday (non-working day),
         # and the customer only allows delivery on weekdays(Monday to Friday),
-        # no valid release channel can be found. This triggers a warning, which
-        # we assert below.
-        with self.assertLogs(level="WARNING"):
-            self._assign_picking(self.picking)
+        # no valid release channel can be found.
+        self._assign_picking(self.picking)
         self.assertNotEqual(self.channel, self.picking.release_channel_id)
         self.channel.process_end_date = today + timedelta(days=4)  # 2023-09-05
         self._assign_picking(self.picking)
@@ -98,9 +96,8 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.channel.process_end_date = today  # Friday
         # Since the channel's end date (Friday) does not match any of the partner's
         # allowed fixed time windows (which are Thursday or Saturday), no valid release
-        # channel can be found. This triggers a warning, which we assert below.
-        with self.assertLogs(level="WARNING"):
-            self._assign_picking(self.picking)
+        # channel can be found.
+        self._assign_picking(self.picking)
         self.assertNotEqual(self.channel, self.picking.release_channel_id)
         self.channel.process_end_date = today + timedelta(
             days=6

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -181,14 +181,9 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         # Asleep the release channel to void the process end date
         # The first call to `action_sleep` ensures the channel is set to 'asleep' state,
         # which prevents pickings from being assigned immediately.
-        # We expect a warning on this transition, hence the log assertion.
-        # When other active channels exist, pickings could otherwise be reassigned to
-        # them. By sleeping this channel and ensuring no reassignment happens,
-        # we preserve the pickings in an unassigned state.
         # Upon calling `action_wake_up`, the channel wakes up and reassigns the pending
         # pickings.
-        with self.assertLogs(level="WARNING"):
-            channel.action_sleep()
+        channel.action_sleep()
         new_pickings = channel.picking_ids.move_ids.move_orig_ids.picking_id
         self.assertFalse(new_pickings)
         channel.invalidate_recordset()


### PR DESCRIPTION
It's common that a delivery cannot be assigned to a channel since the introduction of lifecycle on release channels.
There is no reason to pollute the logs with this normal use case

@rousseldenis @sebalix 