### PR TITLE
[18.0][IMP] stock_release_channel: better logs if no channel assigned

### DIFF
--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -142,11 +142,17 @@ class StockPicking(models.Model):
         :return: release channels
         """
         self.ensure_one()
+        channel_model = self.env["stock.release.channel"]
         domain = self._release_channel_possible_candidate_domain
-        log = self.env.context.get("assign_release_channel_log_stream")
-        if log:
+        if log := self.env.context.get("assign_release_channel_log_stream"):
             log.write(f"Find possible channels domain: {domain}\n")
-        return self.env["stock.release.channel"].search(domain)
+            channel_values = channel_model.search_read(
+                domain=[("state", "!=", "asleep")],
+                fields=channel_model._release_channel_assign_log_fields(),
+            )
+            log.write(f"Active channel values: {channel_values}\n")
+
+        return channel_model.search(domain)
 
     @property
     def _release_channel_possible_candidate_domain(self):

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -1129,3 +1129,11 @@ class StockReleaseChannel(models.Model):
             if best_dt is None:
                 break
         return best_dt
+
+    @api.model
+    def _release_channel_assign_log_fields(self):
+        """Release channel fields to read when logging values"""
+        return [
+            "name",
+            "collect_pickings",
+        ]

--- a/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
@@ -95,3 +95,10 @@ class StockReleaseChannel(models.Model):
         arrival_date = self._add_shipment_lead_time(delivery_date)
         while True:
             delivery_date = yield max(delivery_date, arrival_date)
+
+    @api.model
+    def _release_channel_assign_log_fields(self):
+        extra_fields = [
+            "shipment_date",
+        ]
+        return super()._release_channel_assign_log_fields() + extra_fields


### PR DESCRIPTION
Add available channel values to job logs in case no channel was found for a given picking.

This aims to ease debugging when customer asks "Why wasn't my picking automatically released ?".

With this we now have channels values on top of the channel's domain in the job result value, as well as in the logs.

<img width="2206" height="489" alt="image" src="https://github.com/user-attachments/assets/1bccf18f-ad4e-4ca2-b9fc-035d067ae0fa" />
