### PR TITLE
[18.0][FIX] stock_release_channel: localize

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -1035,17 +1035,17 @@ class StockReleaseChannel(models.Model):
         return False
 
     def _localize(self, dt, tz=None):
-        """Localize a datetime
+        """Localize a naive datetime
 
         Use the given tz or use the tz of the warehouse
         """
         wh_tz = pytz.timezone(tz or self.warehouse_id.partner_id.tz or "UTC")
-        dt_tz = dt.astimezone(pytz.utc).astimezone(wh_tz)
+        dt_tz = pytz.utc.localize(dt).astimezone(wh_tz)
         return dt_tz
 
     @api.model
     def _naive(self, dt_tz, reset_time=False):
-        """Convert a datetime as naive datetime
+        """Convert a localized datetime to a naive datetime
 
         Allow to reset time
         """

--- a/stock_release_channel_warehouse_calendar/models/stock_release_channel.py
+++ b/stock_release_channel_warehouse_calendar/models/stock_release_channel.py
@@ -34,7 +34,7 @@ class StockReleaseChannel(models.Model):
         wh_tz = pytz.timezone(self.warehouse_id.partner_id.tz or "UTC")
         batch_delta = timedelta(days=61)
         while True:
-            delivery_date = delivery_date.astimezone(pytz.utc)
+            delivery_date = pytz.utc.localize(delivery_date)
             work_intervals = calendar._work_intervals_batch(
                 delivery_date, delivery_date + batch_delta, tz=wh_tz
             )[False]
@@ -45,4 +45,4 @@ class StockReleaseChannel(models.Model):
                     delivery_date = yield delivery_date.astimezone(pytz.utc).replace(
                         tzinfo=None
                     )
-                    delivery_date = delivery_date.astimezone(pytz.utc)
+                    delivery_date = pytz.utc.localize(delivery_date)


### PR DESCRIPTION
Fix similar to https://github.com/OCA/stock-logistics-workflow/pull/2353

Convert naive datetime to UTC without relying on system local timezone

cc @yankinmax 